### PR TITLE
Added jdownloader.rb Cask

### DIFF
--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -3,14 +3,16 @@ cask 'jdownloader' do
   sha256 :no_check
 
   if MacOS.release <= :snow_leopard
-    url 'http://installer.jdownloader.org/JD2Setup_10_6orlower.dmg'
+    url 'http://installer.jdownloader.org/clean/JD2Setup_10_6_or_lower.dmg', user_agent: 'HomebrewCask/1.0 (Macintosh; Intel Mac OS X) (+http://caskroom.io)'
   else
-    url 'http://installer.jdownloader.org/JD2Setup.dmg'
+    url 'http://installer.jdownloader.org/clean/JD2Setup.dmg', user_agent: 'HomebrewCask/1.0 (Macintosh; Intel Mac OS X) (+http://caskroom.io)'
   end
 
   name 'JDownloader 2'
   homepage 'http://jdownloader.org/'
   license :gpl
+
+  auto_updates true
 
   app 'JDownloader 2.0/JDownloader2.app'
 


### PR DESCRIPTION
jdownloader cask readded using a different set of download urls provided by it's developer. Fixes https://github.com/caskroom/homebrew-cask/issues/19544.